### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+As a [user], in order to [accomplish some goal], I need [some feature].
+
+[Description, background context, or implementation details]
+
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+<!-- If this issue is a defect, please capture these fields instead, otherwise
+you can remove these. When it makes sense, visuals like screenshots are super
+helpful to include to make sure everyone looking at the issue understands what
+you’re talking about. -->
+
+[Description of defect]
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Steps to reproduce the behavior
+
+1.
+1.
+1.


### PR DESCRIPTION
Adds a template for GH issues so that we can better capture acceptance criteria (a point raised in our retro).