### PR TITLE
Handle centralized agencies in agency finder

### DIFF
--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -9,6 +9,7 @@ import requestapi from '../util/request_api';
 export const types = {
   AGENCY_FINDER_DATA_FETCH: 'AGENCY_FINDER_DATA_FETCH',
   AGENCY_FINDER_DATA_RECEIVE: 'AGENCY_FINDER_DATA_RECEIVE',
+  AGENCY_FINDER_DATA_COMPLETE: 'AGENCY_FINDER_DATA_COMPLETE',
   AGENCY_COMPONENT_FETCH: 'AGENCY_COMPONENT_FETCH',
   AGENCY_COMPONENT_RECEIVE: 'AGENCY_COMPONENT_RECEIVE',
   REQUEST_FORM_UPDATE: 'REQUEST_FORM_UPDATE',
@@ -28,7 +29,8 @@ export const requestActions = {
       .fields('agency', ['name', 'abbreviation', 'description'])
       .fields('agency_component', ['title', 'abbreviation', 'agency'])
       .limit(50) // Maximum allowed by drupal
-      .paginate('/agency_components', requestActions.receiveAgencyFinderData);
+      .paginate('/agency_components', requestActions.receiveAgencyFinderData)
+      .then(requestActions.completeAgencyFinderData);
   },
 
   receiveAgencyFinderData(agencyComponents) {
@@ -38,6 +40,14 @@ export const requestActions = {
     });
 
     return Promise.resolve(agencyComponents);
+  },
+
+  completeAgencyFinderData() {
+    dispatcher.dispatch({
+      type: types.AGENCY_FINDER_DATA_COMPLETE,
+    });
+
+    return Promise.resolve();
   },
 
   fetchAgencyComponent(agencyComponentId) {

--- a/js/components/agency_component_finder.jsx
+++ b/js/components/agency_component_finder.jsx
@@ -23,7 +23,7 @@ function datums({ agencies, agencyComponents }) {
 }
 
 
-class AgencyComponentSelector extends Component {
+class AgencyComponentFinder extends Component {
   componentDidMount() {
     const { agencies, agencyComponents } = this.props;
     this.bloodhound = new Bloodhound({
@@ -117,7 +117,7 @@ class AgencyComponentSelector extends Component {
   }
 }
 
-AgencyComponentSelector.propTypes = {
+AgencyComponentFinder.propTypes = {
   /* eslint-disable react/no-unused-prop-types */
   agencies: PropTypes.instanceOf(Map),
   agencyComponents: PropTypes.instanceOf(List),
@@ -125,9 +125,9 @@ AgencyComponentSelector.propTypes = {
   onAgencyChange: PropTypes.func.isRequired,
 };
 
-AgencyComponentSelector.defaultProps = {
+AgencyComponentFinder.defaultProps = {
   agencies: new Map(),
   agencyComponents: new List(),
 };
 
-export default AgencyComponentSelector;
+export default AgencyComponentFinder;

--- a/js/components/agency_component_finder.jsx
+++ b/js/components/agency_component_finder.jsx
@@ -83,12 +83,20 @@ class AgencyComponentFinder extends Component {
       return;
     }
 
+    function display(datum) {
+      return datum.agency ? `${datum.title} (${datum.agency.name})` : datum.title;
+    }
+
     this.typeahead = $(this.typeaheadInput).typeahead({
       highlight: true,
     }, {
       name: 'agencies',
-      display: (datum => (datum.agency ? `${datum.title} (${datum.agency.name})` : datum.title)),
+      display,
       source: this.bloodhound.ttAdapter(),
+      templates: {
+        suggestion: datum =>
+          $('<div>').addClass(datum.type).text(display(datum)),
+      },
     })
       .bind('typeahead:select', (e, suggestion) => this.props.onAgencyChange(suggestion));
   }

--- a/js/components/agency_component_finder.jsx
+++ b/js/components/agency_component_finder.jsx
@@ -15,22 +15,40 @@ if (typeof window !== 'undefined') {
 
 // Expects agencies as a sequence type
 function datums({ agencies, agencyComponents }) {
-  return agencies.toJS()
-    // Add a title property for common displayKey
-    .map(agency => Object.assign({}, agency, { title: agency.name }))
-    // Include agency components in typeahead
-    .concat(agencyComponents.toJS());
+  // Keep an index of centralized agencies for quick lookup
+  const centralizedAgencyIndex = {};
+
+  return agencies
+    .map((agency) => {
+      if (agency.isCentralized()) {
+        // Warning: Side-effect
+        // Add the agency to the index of centralized agencies
+        centralizedAgencyIndex[agency.id] = true;
+      }
+
+      // Add a title property for common displayKey
+      return Object.assign(agency.toJS(), { title: agency.name });
+    })
+    .toJS()
+    // Include decentralized agency components in typeahead
+    .concat(
+      agencyComponents.toJS().filter(
+        agencyComponent => !(agencyComponent.agency.id in centralizedAgencyIndex),
+      ),
+    );
 }
 
 
 class AgencyComponentFinder extends Component {
+  constructor(props) {
+    super(props);
+
+    this.isIndexed = false;
+  }
+
   componentDidMount() {
-    const { agencies, agencyComponents } = this.props;
     this.bloodhound = new Bloodhound({
-      local: datums({
-        agencies: agencies.valueSeq(), // Pull the values, convert to sequence
-        agencyComponents,
-      }),
+      local: [],
       queryTokenizer: Bloodhound.tokenizers.whitespace,
       datumTokenizer: datum => (
         datum.type === 'agency' ?
@@ -54,6 +72,13 @@ class AgencyComponentFinder extends Component {
       ),
     });
 
+    // If we have all the data already then index it. If we're still waiting on
+    // data, we'll index when we receive the complete props.
+    if (this.props.agencyFinderDataComplete) {
+      this.index(this.props);
+    }
+
+    // Initialize the typeahead input element
     if (!this.typeaheadInput) {
       return;
     }
@@ -69,18 +94,34 @@ class AgencyComponentFinder extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.agencies.equals(nextProps.agencies)
-        && this.props.agencyComponents.equals(nextProps.agencyComponents)) {
+    // Indexing the typeahead is expensive and if we do it in batches, it gets
+    // complicated to calculate which agencies are centralized vs
+    // decentralized. Wait until we've received all the agency finder data
+    // before indexing.
+    if (!nextProps.agencyFinderDataComplete) {
       return;
     }
 
-    const differenceAgencies = nextProps.agencies.toSet().subtract(this.props.agencies.toSet());
-    const differenceAgencyComponents =
-      nextProps.agencyComponents.toSet().subtract(this.props.agencyComponents.toSet());
+    this.index(nextProps);
+  }
 
+  index(props) {
+    if (this.isIndexed) {
+      return;
+    }
+
+    // There is no update, only initialize. We assume that the component is only
+    // initialized after all the data is ready. Any updates are not significant
+    // enough to warrant an update. We only need title and abbreviation to
+    // render which should be available once the agency finder data fetch is
+    // complete.
+    this.isIndexed = true;
+    const { agencies, agencyComponents } = props;
+
+    this.bloodhound.clear(); // Just in case
     this.bloodhound.add(datums({
-      agencies: differenceAgencies,
-      agencyComponents: differenceAgencyComponents,
+      agencies: agencies.valueSeq(), // Pull the values, convert to sequence
+      agencyComponents,
     }));
   }
 
@@ -123,6 +164,7 @@ AgencyComponentFinder.propTypes = {
   agencyComponents: PropTypes.instanceOf(List),
   /* eslint-enable react/no-unused-prop-types */
   onAgencyChange: PropTypes.func.isRequired,
+  agencyFinderDataComplete: PropTypes.bool.isRequired,
 };
 
 AgencyComponentFinder.defaultProps = {

--- a/js/components/agency_component_preview.jsx
+++ b/js/components/agency_component_preview.jsx
@@ -8,15 +8,15 @@ import PrettyUrl from './pretty_url';
 import { AgencyComponent } from '../models';
 
 
-function AgencyComponentPreview({ agencyComponent }) {
+function AgencyComponentPreview({ agencyComponent, isCentralized }) {
   const description = AgencyComponent.agencyMission(agencyComponent);
   const requestUrl = `/request/agency-component/${agencyComponent.id}/`;
 
   return (
     <div className="agency-preview usa-grid-full">
       <div className="usa-width-one-whole">
-        <h2>{agencyComponent.agency.name}</h2>
-        <h3>{agencyComponent.title}</h3>
+        { !isCentralized && <h2>{agencyComponent.agency.name}</h2> }
+        <h3>{isCentralized ? agencyComponent.agency.name : agencyComponent.title }</h3>
       </div>
       <div className="usa-width-one-half">
         { description &&
@@ -67,6 +67,7 @@ function AgencyComponentPreview({ agencyComponent }) {
 
 AgencyComponentPreview.propTypes = {
   agencyComponent: PropTypes.object.isRequired,
+  isCentralized: PropTypes.bool.isRequired,
 };
 
 

--- a/js/components/agency_component_preview.jsx
+++ b/js/components/agency_component_preview.jsx
@@ -42,9 +42,15 @@ function AgencyComponentPreview({ onAgencySelect, agencyComponent, isCentralized
         }
 
         <h4>Contact</h4>
-        <PrettyUrl href={agencyComponent.website.uri} />
-        <FoiaPersonnel foiaPersonnel={agencyComponent.public_liaisons[0]} />
-        <FoiaSubmissionAddress submissionAddress={agencyComponent.submission_address} />
+        <div className="agency-preview_contact-section">
+          { agencyComponent.website && <PrettyUrl href={agencyComponent.website.uri} /> }
+        </div>
+        <div className="agency-preview_contact-section">
+          <FoiaPersonnel foiaPersonnel={agencyComponent.public_liaisons[0]} />
+        </div>
+        <div className="agency-preview_contact-section">
+          <FoiaSubmissionAddress submissionAddress={agencyComponent.submission_address} />
+        </div>
 
       </div>
       <div className="usa-width-one-half">

--- a/js/components/agency_component_preview.jsx
+++ b/js/components/agency_component_preview.jsx
@@ -53,7 +53,7 @@ function AgencyComponentPreview({ onAgencySelect, agencyComponent, isCentralized
         </div>
 
       </div>
-      <div className="usa-width-one-half">
+      <div className="usa-width-one-half start-request-container">
         { agencyComponent.request_data_year &&
           <div>
             <h4>Average processing time</h4>

--- a/js/components/agency_component_preview.jsx
+++ b/js/components/agency_component_preview.jsx
@@ -55,14 +55,8 @@ function AgencyComponentPreview({ onAgencySelect, agencyComponent, isCentralized
       </div>
       <div className="usa-width-one-half start-request-container">
         { agencyComponent.request_data_year &&
-          <div>
-            <h4>Average processing time</h4>
-            <AgencyComponentProcessingTime
-              agencyComponent={agencyComponent}
-            />
-          </div>
+          <AgencyComponentProcessingTime agencyComponent={agencyComponent} />
         }
-
         <h4>
           The records or information you&rsquo;re looking for may already be public.
         </h4>

--- a/js/components/agency_component_preview.jsx
+++ b/js/components/agency_component_preview.jsx
@@ -8,14 +8,29 @@ import PrettyUrl from './pretty_url';
 import { AgencyComponent } from '../models';
 
 
-function AgencyComponentPreview({ agencyComponent, isCentralized }) {
+function AgencyComponentPreview({ onAgencySelect, agencyComponent, isCentralized }) {
   const description = AgencyComponent.agencyMission(agencyComponent);
   const requestUrl = `/request/agency-component/${agencyComponent.id}/`;
+  const onSelect = () => onAgencySelect(agencyComponent.agency);
 
   return (
     <div className="agency-preview usa-grid-full">
       <div className="usa-width-one-whole">
-        { !isCentralized && <h2>{agencyComponent.agency.name}</h2> }
+        {
+          !isCentralized && (
+            <h2>
+              <span // eslint-disable-line jsx-a11y/no-static-element-interactions
+                className="agency-preview_agency-back"
+                onClick={onSelect}
+                onKeyPress={onSelect}
+                role="button"
+                tabIndex="0"
+              >
+                {agencyComponent.agency.name}
+              </span>
+            </h2>
+          )
+        }
         <h3>{isCentralized ? agencyComponent.agency.name : agencyComponent.title }</h3>
       </div>
       <div className="usa-width-one-half">
@@ -66,6 +81,7 @@ function AgencyComponentPreview({ agencyComponent, isCentralized }) {
 }
 
 AgencyComponentPreview.propTypes = {
+  onAgencySelect: PropTypes.func.isRequired,
   agencyComponent: PropTypes.object.isRequired,
   isCentralized: PropTypes.bool.isRequired,
 };

--- a/js/components/agency_component_preview.jsx
+++ b/js/components/agency_component_preview.jsx
@@ -66,7 +66,7 @@ function AgencyComponentPreview({ onAgencySelect, agencyComponent, isCentralized
         <h4>
           The records or information you&rsquo;re looking for may already be public.
         </h4>
-        { agencyComponent.website.uri &&
+        { agencyComponent.website &&
           <p>
             Visit the agency’s <a href={agencyComponent.website.uri}>website</a> to learn more.
           </p>

--- a/js/components/agency_component_processing_time.jsx
+++ b/js/components/agency_component_processing_time.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+function tryRoundInt(string) {
+  const number = Math.ceil(parseFloat(string, 10));
+  return Number.isNaN(number) ? string : number;
+}
+
 
 function AgencyComponentProcessingTime({ agencyComponent }) {
   if (!agencyComponent.request_data_year) {
@@ -8,10 +13,8 @@ function AgencyComponentProcessingTime({ agencyComponent }) {
     return null;
   }
 
-  const {
-    request_data_complex_average_days: complex_average_days,
-    request_data_simple_average_days: simple_average_days,
-  } = agencyComponent;
+  const complex_average_days = tryRoundInt(agencyComponent.request_data_complex_average_days);
+  const simple_average_days = tryRoundInt(agencyComponent.request_data_simple_average_days);
   return (
     <div>
       <h5>Average processing time for {agencyComponent.request_data_year}</h5>

--- a/js/components/foia_personnel.jsx
+++ b/js/components/foia_personnel.jsx
@@ -18,15 +18,15 @@ function FoiaPersonnel({ foiaPersonnel }) {
   const email = (foiaPersonnel.email || '').toLowerCase();
   return (
     <div>
-      <p className="submission-help_poc">{ displayName(foiaPersonnel) }</p>
+      <div className="submission-help_poc">{ displayName(foiaPersonnel) }</div>
       {
         (foiaPersonnel.phone || [])
-          .map(phone => <p className="submission-help_phone" key={phone} >{ phone }</p>)
+          .map(phone => <div className="submission-help_phone" key={phone}>{ phone }</div>)
       }
       { foiaPersonnel.email &&
-        <p className="submission-help_email">
+        <div className="submission-help_email">
           <a href={`mailto:${email}`}>{ email }</a>
-        </p>
+        </div>
       }
     </div>
   );

--- a/js/components/foia_submission_address.jsx
+++ b/js/components/foia_submission_address.jsx
@@ -12,12 +12,18 @@ function FoiaSubmissionAddress({ submissionAddress }) {
     postal_code,
   } = submissionAddress;
 
+  // Address line seems to have been parsed wrong, it seems to be: name,
+  // title, department, suite. And then address_line2 is actually line1.
+  const [name, title, department, suite] = address_line1.split(',', 4);
+
   return (
     <address className="submission-help_mailing">
-      <p>{ additional_name }</p>
-      <p>{ address_line1 }</p>
-      <p>{ address_line2 }</p>
-      <p>{ `${locality}, ${administrative_area} ${postal_code}` }</p>
+      <div>{ additional_name }</div>
+      <div>{ [name, title].join(',') }</div>
+      <div>{ department }</div>
+      <div>{ suite }</div>
+      <div>{ address_line2 }</div>
+      <div>{ `${locality}, ${administrative_area} ${postal_code}` }</div>
     </address>
   );
 }

--- a/js/components/landing.jsx
+++ b/js/components/landing.jsx
@@ -97,11 +97,11 @@ class LandingComponent extends Component {
           !this.state.agencyComponent && !this.state.agency &&
             <div>
               <h3 className="agency-component-search_hed">When choosing an agency</h3>
-	      <p>Remember that some agencies have existing FOIA portals and will
-	      continue to receive requests through their current portals. All
-	      agencies are working towards becoming interoperable with FOIA.gov.
-	      The information for where to submit a request to those agencies
-	      will be available after you select an agency above.</p>
+              <p>Remember that some agencies have existing FOIA portals and will
+              continue to receive requests through their current portals. All
+              agencies are working towards becoming interoperable with FOIA.gov.
+              The information for where to submit a request to those agencies
+              will be available after you select an agency above.</p>
             </div>
         }
         {

--- a/js/components/landing.jsx
+++ b/js/components/landing.jsx
@@ -24,7 +24,7 @@ class LandingComponent extends Component {
       // properties might not be consistent.
 
       if (agencyComponent.type === 'agency') {
-        const agency = agencyComponentStore.getAgency(agencyComponent.abbreviation);
+        const agency = agencyComponentStore.getAgency(agencyComponent.id);
         const agencyComponentsForAgency =
           agencyComponentStore.getAgencyComponentsForAgency(agency.id);
         this.setState({

--- a/js/components/landing.jsx
+++ b/js/components/landing.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { requestActions } from 'actions';
-import AgencyComponentSelector from 'components/agency_component_selector';
+import AgencyComponentFinder from 'components/agency_component_finder';
 import AgencyComponentPreview from 'components/agency_component_preview';
 import AgencyPreview from 'components/agency_preview';
 import agencyComponentStore from '../stores/agency_component';
@@ -53,7 +53,7 @@ class LandingComponent extends Component {
         <h2>
           Select an agency to start your request or to see an agency’s contact information:
         </h2>
-        <AgencyComponentSelector
+        <AgencyComponentFinder
           agencies={agencies}
           agencyComponents={agencyComponents}
           onAgencyChange={agencyChange}

--- a/js/components/landing.jsx
+++ b/js/components/landing.jsx
@@ -47,7 +47,7 @@ class LandingComponent extends Component {
         });
     };
 
-    const { agencies, agencyComponents } = this.props;
+    const { agencies, agencyComponents, agencyFinderDataComplete } = this.props;
     return (
       <div className="usa-grid">
         <h2>
@@ -56,6 +56,7 @@ class LandingComponent extends Component {
         <AgencyComponentFinder
           agencies={agencies}
           agencyComponents={agencyComponents}
+          agencyFinderDataComplete={agencyFinderDataComplete}
           onAgencyChange={agencyChange}
         />
         {
@@ -84,8 +85,9 @@ class LandingComponent extends Component {
 }
 
 LandingComponent.propTypes = {
-  agencyComponents: PropTypes.object.isRequired,
   agencies: PropTypes.object.isRequired,
+  agencyComponents: PropTypes.object.isRequired,
+  agencyFinderDataComplete: PropTypes.bool.isRequired,
 };
 
 export default LandingComponent;

--- a/js/components/landing.jsx
+++ b/js/components/landing.jsx
@@ -82,7 +82,7 @@ class LandingComponent extends Component {
     const { agencies, agencyComponents, agencyFinderDataComplete } = this.props;
     return (
       <div className="usa-grid">
-        <h2>
+        <h2 className="agency-component-search_hed">
           Select an agency to start your request or to see an agency’s contact information:
         </h2>
         <div ref={(e) => { this.agencyFinderElement = e; }}>
@@ -95,11 +95,14 @@ class LandingComponent extends Component {
         </div>
         {
           !this.state.agencyComponent && !this.state.agency &&
-          <p>Remember that some agencies have existing FOIA portals and will
-          continue to receive requests through their current portals. All
-          agencies are working towards becoming interoperable with FOIA.gov.
-          The information for where to submit a request to those agencies
-          will be available after you select an agency above.</p>
+            <div>
+              <h3 className="agency-component-search_hed">When choosing an agency</h3>
+	      <p>Remember that some agencies have existing FOIA portals and will
+	      continue to receive requests through their current portals. All
+	      agencies are working towards becoming interoperable with FOIA.gov.
+	      The information for where to submit a request to those agencies
+	      will be available after you select an agency above.</p>
+            </div>
         }
         {
           this.state.agencyComponent &&

--- a/js/components/landing.jsx
+++ b/js/components/landing.jsx
@@ -36,6 +36,13 @@ class LandingComponent extends Component {
   }
 
   render() {
+    // Recursively traverse up the DOM to figure out the scroll offset
+    function scrollOffset(element) {
+      return element.offsetParent ?
+        element.offsetTop + scrollOffset(element.offsetParent) :
+        element.offsetTop;
+    }
+
     // Note that the agencyComponent comes from two different sources, so the
     // properties might not be consistent.
     const agencyChange = (agencyComponent) => {
@@ -44,6 +51,9 @@ class LandingComponent extends Component {
           .then(requestActions.receiveAgencyComponent)
           .then(() => agencyComponentStore.getAgencyComponent(agencyComponentId));
       }
+
+      // Scroll to back to the agency finder
+      window.scrollTo(0, scrollOffset(this.agencyFinderElement));
 
       if (agencyComponent.type === 'agency_component') {
         fetchAgencyComponent(agencyComponent.id)
@@ -75,12 +85,14 @@ class LandingComponent extends Component {
         <h2>
           Select an agency to start your request or to see an agency’s contact information:
         </h2>
-        <AgencyComponentFinder
-          agencies={agencies}
-          agencyComponents={agencyComponents}
-          agencyFinderDataComplete={agencyFinderDataComplete}
-          onAgencyChange={agencyChange}
-        />
+        <div ref={(e) => { this.agencyFinderElement = e; }}>
+          <AgencyComponentFinder
+            agencies={agencies}
+            agencyComponents={agencyComponents}
+            agencyFinderDataComplete={agencyFinderDataComplete}
+            onAgencyChange={agencyChange}
+          />
+        </div>
         {
           !this.state.agencyComponent && !this.state.agency &&
           <p>Remember that some agencies have existing FOIA portals and will

--- a/js/components/landing.jsx
+++ b/js/components/landing.jsx
@@ -94,6 +94,7 @@ class LandingComponent extends Component {
           <AgencyComponentPreview
             agencyComponent={this.state.agencyComponent.toJS()}
             isCentralized={this.state.isCentralized}
+            onAgencySelect={agencyChange}
           />
         }
         {

--- a/js/components/pretty_url.jsx
+++ b/js/components/pretty_url.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import url from 'url';
 
 function parseDomain(href) {
-  return url.parse(href).host;
+  return `${url.parse(href).host}/…`;
 }
 
 function PrettyUrl({ className, href, children }) {

--- a/js/models/agency.js
+++ b/js/models/agency.js
@@ -2,6 +2,9 @@ import { Record } from 'immutable';
 
 const defaults = {
   abbreviation: null,
+  // component_count is not from the API, we track the number of components to
+  // determine is_centralized
+  component_count: 0,
   description: {},
   id: null,
   links: {},
@@ -12,6 +15,17 @@ const defaults = {
 class Agency extends Record(defaults) {
   mission() {
     return this.description && this.description.value;
+  }
+
+  // This is complicated to calculate on the client. The API should provide an
+  // is_centralized property https://github.com/18F/beta.foia.gov/issues/242
+  //
+  // This function is only valid _after_ the AGENCY_FINDER_DATA_COMPLETE action
+  // fires. If you use it before then, it is not accurate. This is because we
+  // can't determine if an agency is centralized until we fetch _all_ agency
+  // components so that we can count them.
+  isCentralized() {
+    return this.component_count === 1;
   }
 }
 

--- a/js/pages/landing.jsx
+++ b/js/pages/landing.jsx
@@ -12,10 +12,16 @@ class LandingPage extends Component {
   }
 
   static calculateState() {
-    const { agencyComponents, agencies } = agencyComponentStore.getState();
+    const {
+      agencies,
+      agencyComponents,
+      agencyFinderDataComplete,
+    } = agencyComponentStore.getState();
+
     return {
       agencies,
       agencyComponents,
+      agencyFinderDataComplete,
     };
   }
 
@@ -31,9 +37,13 @@ class LandingPage extends Component {
 
 
   render() {
-    const { agencies, agencyComponents } = this.state;
+    const { agencies, agencyComponents, agencyFinderDataComplete } = this.state;
     return (
-      <LandingComponent agencies={agencies} agencyComponents={agencyComponents} />
+      <LandingComponent
+        agencies={agencies}
+        agencyComponents={agencyComponents}
+        agencyFinderDataComplete={agencyFinderDataComplete}
+      />
     );
   }
 }

--- a/js/pages/request_landing.jsx
+++ b/js/pages/request_landing.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Container } from 'flux/utils';
 
 import { requestActions } from 'actions';
-import AgencyComponentSelector from 'components/agency_component_selector';
+import AgencyComponentFinder from 'components/agency_component_finder';
 import agencyComponentStore from '../stores/agency_component';
 
 
@@ -47,7 +47,7 @@ class RequestLandingPage extends Component {
       <div id="request-landing-page" className="usa-grid">
         <div className="usa-width-one-whole">
           <h1>Select an agency to make a FOIA request</h1>
-          <AgencyComponentSelector
+          <AgencyComponentFinder
             agencies={agencies}
             agencyComponents={agencyComponents}
             onAgencyChange={agencyChange}

--- a/js/stores/agency_component.js
+++ b/js/stores/agency_component.js
@@ -50,7 +50,10 @@ class AgencyComponentStore extends Store {
                 new Agency(), // not set value
                 (existingAgency) => {
                   const { component_count } = existingAgency;
-                  return existingAgency.merge(agency, { component_count: component_count + 1 });
+                  return existingAgency.merge(
+                    new Agency(agency),
+                    { component_count: component_count + 1 },
+                  );
                 },
               );
             });

--- a/js/stores/agency_component.js
+++ b/js/stores/agency_component.js
@@ -13,6 +13,7 @@ class AgencyComponentStore extends Store {
     this.state = {
       agencies: new Map(),
       agencyComponents: new List(),
+      agencyFinderDataComplete: false,
     };
   }
 
@@ -41,28 +42,34 @@ class AgencyComponentStore extends Store {
         const { agencyComponents: receivedAgencyComponents } = payload;
         const { agencies, agencyComponents } = this.state;
 
-        // Pull out agencies, keyed by it's abbreviation
-        const receivedAgencies = receivedAgencyComponents
-          .map(agencyComponent => agencyComponent.agency)
-          .reduce((memo, agency) => {
-            if (agency.abbreviation in memo) {
-              return memo;
-            }
-
-            // We add a type (in the model) so we can distinguish them from
-            // agency_components.  It's a shame because this info is included
-            // in the original jsonapi response, but the parser looses it.
-            // https://github.com/mysidewalk/jsonapi-parse/issues/2
-            return Object.assign(memo, { [agency.abbreviation]: new Agency(agency) });
-          }, {});
+        const updatedAgencies = agencies.withMutations((mutableAgencies) => {
+          receivedAgencyComponents
+            .map(agencyComponent => agencyComponent.agency)
+            .forEach((agency) => {
+              mutableAgencies.update(
+                agency.abbreviation,
+                new Agency(), // not set value
+                (existingAgency) => {
+                  const { component_count } = existingAgency;
+                  return existingAgency.merge(agency, { component_count: component_count + 1 });
+                },
+              );
+            });
+        });
 
         // Merge state
         Object.assign(this.state, {
-          agencies: agencies.merge(receivedAgencies),
+          agencies: updatedAgencies,
           agencyComponents: agencyComponents.concat(
             receivedAgencyComponents.map(agencyComponent => new AgencyComponent(agencyComponent)),
           ),
         });
+        this.__emitChange();
+        break;
+      }
+
+      case types.AGENCY_FINDER_DATA_COMPLETE: {
+        this.state.agencyFinderDataComplete = true;
         this.__emitChange();
         break;
       }

--- a/js/stores/agency_component.js
+++ b/js/stores/agency_component.js
@@ -21,9 +21,8 @@ class AgencyComponentStore extends Store {
     return this.state;
   }
 
-  getAgency(abbreviation) {
-    // TODO we should probably key this on id instead of abbreviation
-    return this.state.agencies.get(abbreviation, null);
+  getAgency(agencyId) {
+    return this.state.agencies.get(agencyId, null);
   }
 
   getAgencyComponent(agencyComponentId) {
@@ -47,7 +46,7 @@ class AgencyComponentStore extends Store {
             .map(agencyComponent => agencyComponent.agency)
             .forEach((agency) => {
               mutableAgencies.update(
-                agency.abbreviation,
+                agency.id,
                 new Agency(), // not set value
                 (existingAgency) => {
                   const { component_count } = existingAgency;

--- a/www.foia.gov/_sass/base/_typography.scss
+++ b/www.foia.gov/_sass/base/_typography.scss
@@ -120,10 +120,8 @@ p {
   }
 }
 
-p a {
+%a-colors {
   color: $color-primary-darkest;
-  text-decoration: none;
-  border-bottom: 1px solid $color-primary-alt;
   &:hover,
   &:active {
     color: $color-primary;
@@ -139,4 +137,10 @@ p a {
 
 address p {
   margin: 0;
+}
+
+p a {
+  @extend %a-colors;
+  text-decoration: none;
+  border-bottom: 1px solid $color-primary-alt;
 }

--- a/www.foia.gov/_sass/base/_typography.scss
+++ b/www.foia.gov/_sass/base/_typography.scss
@@ -10,6 +10,9 @@ $h4-leading: $base-line-height;
 $h5-leading: $heading-line-height;
 $p-leading:  1.5;
 
+$body-copy-max-width: $space-1x * 78;
+
+
 // Heading 1
 h1 {
   font-size: $h1-font-size-mobile;
@@ -83,6 +86,18 @@ p {
   &.secondary-text {
     font-size: 1.5rem;
   }
+}
+
+// Body copy max-width
+h1,
+h2,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  max-width: $body-copy-max-width;
 }
 
 %external-url {

--- a/www.foia.gov/_sass/base/_typography.scss
+++ b/www.foia.gov/_sass/base/_typography.scss
@@ -85,6 +85,26 @@ p {
   }
 }
 
+%external-url {
+  margin-right: 2rem;
+  position: relative;
+
+  &:after {
+    content: '\01F517'; // TODO This should be a background image, waiting for glyphs from design
+    display: inline-block;
+    height: 1rem;
+    position: absolute;
+    width: 1rem;
+  }
+}
+
+#main {
+  a:not([href*='foia.gov/']):not([href^='#']):not([href^='/']):not([href^='mailto:']),
+  a[target=_blank] {
+    @extend %external-url;
+  }
+}
+
 p a {
   color: $color-primary-darkest;
   text-decoration: none;

--- a/www.foia.gov/_sass/modules/_agency_component_search.scss
+++ b/www.foia.gov/_sass/modules/_agency_component_search.scss
@@ -5,7 +5,6 @@ $section-padding-bottom: $space-1x * 11;
   border-top: $space-2x solid $color-primary-alt;
   padding-top: $space-5x;
   padding-bottom: $section-padding-bottom;
-  position: relative;
   .start-request {
     font-weight: $font-bold;
   }

--- a/www.foia.gov/_sass/modules/_agency_component_search.scss
+++ b/www.foia.gov/_sass/modules/_agency_component_search.scss
@@ -1,29 +1,32 @@
+$section-padding-bottom: $space-1x * 11;
+
 .agency-component-search {
   @extend .panel_reverse-color;
   border-top: $space-2x solid $color-primary-alt;
   padding-top: $space-5x;
-  padding-bottom: $space-1x * 11;
+  padding-bottom: $section-padding-bottom;
   position: relative;
   .start-request {
-    position: absolute;
-    bottom: $space-1x * 11;
     font-weight: $font-bold;
   }
+  .start-request-container {
+    position: relative;
 
-  h3 {
-    font-size: $h2-font-size;
-    margin-top: $space-1x;
-    margin-bottom: $space-5x;
-  }
-  h4 {
-    font-size: $base-font-size;
-    font-family: $font-sans;
+    @media all and (min-width: $medium-screen) {
+      // Make space for the start-request button
+      padding-bottom: 5rem;
+
+      .start-request {
+	bottom: 0;
+	position: absolute;
+      }
+    }
   }
   .usa-width-one-half {
     margin-top: $space-4x;
     @media all and (min-width: $medium-screen) {
       border-right: 1px solid $color-primary-alt;
-      padding-right: $space-2x;
+      padding-right: $space-4x;
       &:last-child {
         border: none;
         padding-left: 0;

--- a/www.foia.gov/_sass/modules/_agency_component_search.scss
+++ b/www.foia.gov/_sass/modules/_agency_component_search.scss
@@ -53,14 +53,9 @@
   }
 }
 
-.agency-preview {
-  margin-top: $space-4x;
-  h2 {
-    font-size: $h3-font-size;
-    font-family: $font-serif;
-    font-weight: $font-bold;
-  }
-  .usa-button {
-    position: absolute;
-  }
+.agency-component-search_hed {
+  font-family: $font-sans;
+}
+h3.agency-component-search_hed {
+  font-weight: normal;
 }

--- a/www.foia.gov/_sass/modules/_agency_preview.scss
+++ b/www.foia.gov/_sass/modules/_agency_preview.scss
@@ -1,3 +1,28 @@
+%link-caret {
+  border-bottom: 1px solid $color-primary-alt;
+  color: $color-primary-darkest;
+  cursor: pointer;
+  margin-right: 1em; // Make room for the caret
+  position: relative;
+
+  &:after {
+    bottom: -.2em;
+    content: '>'; // TODO this should be a glyph
+    display: inline-block;
+    font-weight: 900;
+    position: absolute;
+    right: -.8em;
+  }
+}
+
+.agency-preview_agency-back {
+  @extend %link-caret;
+
+  &:after {
+    bottom: -.1em;
+  }
+}
+
 .agency-preview_components {
   list-style: none;
 }
@@ -7,18 +32,5 @@
 }
 
 .agency-preview_component {
-  color: $color-primary-darkest;
-  cursor: pointer;
-  border-bottom: 1px solid $color-primary-alt;
-  position: relative;
-
-  &:after {
-    bottom: -3px;
-    content: '>';
-    display: inline-block;
-    font-size: 16px;
-    font-weight: 900;
-    position: absolute;
-    right: -1.2rem;
-  }
+  @extend %link-caret;
 }

--- a/www.foia.gov/_sass/modules/_agency_preview.scss
+++ b/www.foia.gov/_sass/modules/_agency_preview.scss
@@ -1,5 +1,4 @@
 %link-caret {
-  border-bottom: 1px solid $color-primary-alt;
   color: $color-primary-darkest;
   cursor: pointer;
   margin-right: 1em; // Make room for the caret
@@ -12,6 +11,31 @@
     font-weight: 900;
     position: absolute;
     right: -.8em;
+  }
+}
+
+.agency-preview {
+  margin-top: $space-4x;
+
+  a {
+    @extend %a-colors;
+  }
+
+  h2 {
+    font-family: $font-serif;
+    font-size: $h3-font-size;
+    font-weight: $font-bold;
+  }
+
+  h3 {
+    font-size: $h2-font-size;
+    margin-bottom: $space-5x;
+    margin-top: $space-1x;
+  }
+
+  h4 {
+    font-family: $font-sans;
+    font-size: $base-font-size;
   }
 }
 
@@ -28,6 +52,7 @@
 }
 
 .agency-preview_contact-section {
+  color: $color-primary-darkest;
   margin-bottom: $space-2x;
 }
 

--- a/www.foia.gov/_sass/modules/_agency_preview.scss
+++ b/www.foia.gov/_sass/modules/_agency_preview.scss
@@ -27,6 +27,10 @@
   list-style: none;
 }
 
+.agency-preview_contact-section {
+  margin-bottom: $space-2x;
+}
+
 .agency-preview_list-hed {
   @extend %h2;
 }

--- a/www.foia.gov/_sass/modules/_glossary.scss
+++ b/www.foia.gov/_sass/modules/_glossary.scss
@@ -93,7 +93,14 @@ $z-glossary: 9000; // uswds navigation
   bottom: 0;
   margin: 0;
   position: fixed;
-  right: 2rem;
+
+  @media all and (min-width: $small-screen) {
+    right: 2rem;
+  }
+
+  @media print {
+    display: none;
+  }
 }
 
 .glossary-search {


### PR DESCRIPTION
This adds support for the centralized agencies within the agency finder. It also address the preview related design tweaks in https://github.com/18F/beta.foia.gov/issues/256.

In order to calculate if an agency is centralized, we need all the agency component data. This means we can't initialize the agency finder until all 400+ agency components are loaded, which can be pretty slow, ~7 seconds on dev.

I also added a scroll-to-agency-finder when an agency is selected because clicking the links within decentralized agencies would leave you at the bottom of the page looking at the footer instead of the updated preview content.

![screenshot from 2017-11-01 17-20-31](https://user-images.githubusercontent.com/509703/32304079-cc998376-bf29-11e7-9ee0-b4a1f47b37f6.png)

![screenshot from 2017-11-01 17-20-49](https://user-images.githubusercontent.com/509703/32304083-d0f203b2-bf29-11e7-9125-e639f90e0a96.png)

![screenshot from 2017-11-01 17-21-56](https://user-images.githubusercontent.com/509703/32304092-d9175696-bf29-11e7-80b0-a95578334a11.png)