### PR TITLE
Revert to acquia domains on dev

### DIFF
--- a/js/settings/development.js
+++ b/js/settings/development.js
@@ -1,6 +1,6 @@
 const api = {
-  jsonApiBaseURL: 'https://dev-api.foia.gov/api',
-  requestApiBaseURL: 'https://dev-api.foia.gov/api',
+  jsonApiBaseURL: 'http://foiadev.prod.acquia-sites.com/api',
+  requestApiBaseURL: 'http://foiadev.prod.acquia-sites.com/api',
   // These are not secret, refer to https://github.com/18F/beta.foia.gov/tree/develop/docs/foia-api.md
   jsonApiKey: '7aT5REJTpzjKoYKFuc9YIJLalHdYaif6ZqGkDPxG',
 };


### PR DESCRIPTION
The VPN switchover happened, so our DNS config is out of date. Fall back to the
old domains as a quick fix.