### PR TITLE
Avoid external link treatment in most cases

### DIFF
--- a/www.foia.gov/_sass/base/_typography.scss
+++ b/www.foia.gov/_sass/base/_typography.scss
@@ -114,7 +114,7 @@ p {
 }
 
 #main {
-  a:not([href*='foia.gov/']):not([href^='#']):not([href^='/']):not([href^='mailto:']),
+  a[href^='http']:not([href*='foia.gov/']),
   a[target=_blank] {
     @extend %external-url;
   }


### PR DESCRIPTION
Simplify the rule so only a tags _with_ an `href` that starts with a full http
based url should have the treatmeant. Most other cases (relative links, `#`
links, non-http protocols) should not have the treatment.