### PR TITLE
Proper handling for file input data urls

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@ globals:
   jQuery: true
 rules:
   camelcase: 0
+  no-mixed-operators: 0
   no-plusplus: 0
   no-param-reassign:
     - error

--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -99,9 +99,20 @@ export const requestActions = {
 
     return requestapi.post('/webform/submit', formData, options)
       .catch((error) => {
+        const defaultErrorMessage = 'Sorry, something went wrong and your request could not be submitted.';
         const submissionResult = {
-          errorMessage: 'There was a problem submitting your form.',
+          errorMessage: error.message || defaultErrorMessage,
         };
+
+        if (error.message === 'Network Error') {
+          // Network Error isn't any more helpful than our default message
+          submissionResult.errorMessage = 'The connection failed and your request could not be submitted. Please try again later.';
+        }
+
+        if (error.code === 'ECONNABORTED') {
+          submissionResult.errorMessage =
+            'The connection timed out and your request could not be submitted. Please try again.';
+        }
 
         if (error.response && error.response.data && error.response.data.errors) {
           submissionResult.errors = error.response.data.errors;
@@ -127,6 +138,6 @@ export const requestActions = {
       submissionResult,
     });
 
-    return Promise.resolve();
+    return submissionResult.errorMessage ? Promise.reject() : Promise.resolve();
   },
 };

--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -15,6 +15,7 @@ export const types = {
   REQUEST_FORM_UPDATE: 'REQUEST_FORM_UPDATE',
   REQUEST_FORM_SUBMIT: 'REQUEST_FORM_SUBMIT',
   REQUEST_FORM_SUBMIT_COMPLETE: 'REQUEST_FORM_SUBMIT_COMPLETE',
+  REQUEST_FORM_SUBMIT_PROGRESS: 'REQUEST_FORM_SUBMIT_PROGRESS',
 };
 
 // Action creators, to dispatch actions
@@ -92,7 +93,11 @@ export const requestActions = {
       formData,
     });
 
-    return requestapi.post('/webform/submit', formData)
+    const options = {
+      onUploadProgress: requestActions.submitRequestFormProgress,
+    };
+
+    return requestapi.post('/webform/submit', formData, options)
       .catch((error) => {
         const submissionResult = {
           errorMessage: 'There was a problem submitting your form.',
@@ -105,6 +110,15 @@ export const requestActions = {
         return Promise.resolve(submissionResult);
       })
       .then(requestActions.completeSubmitRequestForm);
+  },
+
+  submitRequestFormProgress(progress) {
+    dispatcher.dispatch({
+      type: types.REQUEST_FORM_SUBMIT_PROGRESS,
+      progress,
+    });
+
+    return Promise.resolve();
   },
 
   completeSubmitRequestForm(submissionResult) {

--- a/js/components/foia_file_widget.jsx
+++ b/js/components/foia_file_widget.jsx
@@ -24,13 +24,13 @@ function parseFile(file) {
       const [properties, filedata] = reader.result.split(',');
 
       // Add filename and size to data-url
-      const augementedProperites = [
+      const augmentedProperties = [
         properties,
         `filename=${encodeURIComponent(file.name)}`,
         `filesize=${file.size}`,
       ].join(';');
 
-      resolve([augementedProperites, filedata].join(','));
+      resolve([augmentedProperties, filedata].join(','));
     });
 
     reader.addEventListener('error', () => {

--- a/js/components/foia_file_widget.jsx
+++ b/js/components/foia_file_widget.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { dataUrlToAttachment } from '../util/attachment';
+
+function dataUrlToFileInfo(dataUrl) {
+  const attachment = dataUrlToAttachment(dataUrl);
+  if (!attachment) {
+    return null;
+  }
+
+  return {
+    name: attachment.filename,
+    type: attachment.content_type,
+    size: attachment.filesize,
+  };
+}
+
+
+function parseFile(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () => {
+      const [properties, filedata] = reader.result.split(',');
+
+      // Add filename and size to data-url
+      const augementedProperites = [
+        properties,
+        `filename=${encodeURIComponent(file.name)}`,
+        `filesize=${file.size}`,
+      ].join(';');
+
+      resolve([augementedProperites, filedata].join(','));
+    });
+
+    reader.addEventListener('error', () => {
+      reject(reader.error);
+    });
+
+    reader.readAsDataURL(file);
+  });
+}
+
+
+class FoiaFileWidget extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: props.value, // dataUrl
+      fileInfo: dataUrlToFileInfo(props.value),
+    };
+  }
+
+  render() {
+    const onChange = (e) => {
+      parseFile(e.target.files[0])
+        .then((dataUrl) => {
+          this.setState({
+            value: dataUrl,
+            attachment: dataUrlToFileInfo(dataUrl),
+          }, () => {
+            this.props.onChange(dataUrl);
+          });
+        });
+    };
+
+    const {
+      disabled,
+      id,
+      readonly,
+    } = this.props;
+
+    const { name, type, size } = this.state.attachment || {};
+    return (
+      <div>
+        <input
+          id={id}
+          type="file"
+          disabled={readonly || disabled}
+          onChange={onChange}
+          defaultValue=""
+        />
+        { this.state.attachment &&
+          <div><strong>{name}</strong> ({type}, {size} bytes)</div>
+        }
+      </div>
+    );
+  }
+}
+
+FoiaFileWidget.propTypes = {
+  disabled: PropTypes.bool,
+  id: PropTypes.string,
+  readonly: PropTypes.bool,
+  onChange: PropTypes.func,
+  value: PropTypes.string,
+};
+
+FoiaFileWidget.defaultProps = {
+  id: '',
+  disabled: false,
+  onChange: () => {},
+  readonly: false,
+  value: '',
+};
+
+export default FoiaFileWidget;

--- a/js/components/foia_file_widget.jsx
+++ b/js/components/foia_file_widget.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { dataUrlToAttachment } from '../util/attachment';
 
 function dataUrlToFileInfo(dataUrl) {
-  const attachment = dataUrlToAttachment(dataUrl);
+  const [attachment] = dataUrlToAttachment(dataUrl);
   if (!attachment) {
     return null;
   }
@@ -58,7 +58,7 @@ class FoiaFileWidget extends React.Component {
         .then((dataUrl) => {
           this.setState({
             value: dataUrl,
-            attachment: dataUrlToFileInfo(dataUrl),
+            fileInfo: dataUrlToFileInfo(dataUrl),
           }, () => {
             this.props.onChange(dataUrl);
           });
@@ -71,7 +71,7 @@ class FoiaFileWidget extends React.Component {
       readonly,
     } = this.props;
 
-    const { name, type, size } = this.state.attachment || {};
+    const { name, type, size } = this.state.fileInfo || {};
     return (
       <div>
         <input
@@ -81,7 +81,7 @@ class FoiaFileWidget extends React.Component {
           onChange={onChange}
           defaultValue=""
         />
-        { this.state.attachment &&
+        { this.state.fileInfo &&
           <div><strong>{name}</strong> ({type}, {size} bytes)</div>
         }
       </div>

--- a/js/components/foia_request_form.jsx
+++ b/js/components/foia_request_form.jsx
@@ -83,17 +83,17 @@ function FoiaRequestForm({ formData, upload, onSubmit, requestForm, submissionRe
           your request.  If you don’t hear from the agency, please reach out
           using the contact information provided to you on this site.</p>
         </div>
-        <button
-          className="usa-button usa-button-big usa-button-primary-alt"
-          type="submit"
-        >
-          Submit request
-        </button>
-        { upload.get('inProgress') &&
+        { upload.get('inProgress') ?
           <UploadProgress
             progressTotal={upload.get('progressTotal')}
             progressLoaded={upload.get('progressLoaded')}
-          />
+          /> :
+	  <button
+	    className="usa-button usa-button-big usa-button-primary-alt"
+	    type="submit"
+	  >
+	    Submit request
+	  </button>
         }
         { submissionResult.errorMessage &&
           <p>

--- a/js/components/foia_request_form.jsx
+++ b/js/components/foia_request_form.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Form from 'react-jsonschema-form';
+import { Map } from 'immutable';
 
 import CustomFieldTemplate from 'components/request_custom_field_template';
 import USWDSRadioWidget from 'components/uswds_radio_widget';
@@ -11,9 +12,10 @@ import ObjectFieldTemplate from './object_field_template';
 import rf from '../util/request_form';
 import FoiaFileWidget from './foia_file_widget';
 import { dataUrlToAttachment, findFileFields } from '../util/attachment';
+import UploadProgress from './upload_progress';
 
 
-function FoiaRequestForm({ formData, isSubmitting, onSubmit, requestForm, submissionResult }) {
+function FoiaRequestForm({ formData, upload, onSubmit, requestForm, submissionResult }) {
   function onChange({ formData: data }) {
     requestActions.updateRequestForm(data);
   }
@@ -59,7 +61,7 @@ function FoiaRequestForm({ formData, isSubmitting, onSubmit, requestForm, submis
   return (
     <Form
       className="foia-request-form"
-      disabled={isSubmitting}
+      disabled={upload.get('inProgress')}
       FieldTemplate={CustomFieldTemplate}
       formContext={formContext}
       formData={formData.toJS()}
@@ -87,6 +89,12 @@ function FoiaRequestForm({ formData, isSubmitting, onSubmit, requestForm, submis
         >
           Submit request
         </button>
+        { upload.get('inProgress') &&
+          <UploadProgress
+            progressTotal={upload.get('progressTotal')}
+            progressLoaded={upload.get('progressLoaded')}
+          />
+        }
         { submissionResult.errorMessage &&
           <p>
             <span className="usa-input-error-message" role="alert">
@@ -101,7 +109,7 @@ function FoiaRequestForm({ formData, isSubmitting, onSubmit, requestForm, submis
 
 FoiaRequestForm.propTypes = {
   formData: PropTypes.object.isRequired,
-  isSubmitting: PropTypes.bool.isRequired,
+  upload: PropTypes.instanceOf(Map).isRequired,
   onSubmit: PropTypes.func,
   requestForm: PropTypes.object.isRequired,
   submissionResult: PropTypes.instanceOf(SubmissionResult).isRequired,

--- a/js/components/foia_request_form.jsx
+++ b/js/components/foia_request_form.jsx
@@ -88,12 +88,12 @@ function FoiaRequestForm({ formData, upload, onSubmit, requestForm, submissionRe
             progressTotal={upload.get('progressTotal')}
             progressLoaded={upload.get('progressLoaded')}
           /> :
-	  <button
-	    className="usa-button usa-button-big usa-button-primary-alt"
-	    type="submit"
-	  >
-	    Submit request
-	  </button>
+          <button
+            className="usa-button usa-button-big usa-button-primary-alt"
+            type="submit"
+          >
+            Submit request
+          </button>
         }
         { submissionResult.errorMessage &&
           <p>

--- a/js/components/upload_progress.jsx
+++ b/js/components/upload_progress.jsx
@@ -4,18 +4,13 @@ import PropTypes from 'prop-types';
 
 function UploadProgress({ progressLoaded, progressTotal }) {
   const percentage = Math.floor(progressLoaded / progressTotal * 100);
+  // Use a fallback in case we're not receiving progress events. In that case
+  // the requester will just see "Uploading…" until the request is complete.
+  const content = progressLoaded ? `${percentage}% uploaded…` : 'Uploading…';
   return (
-    <div>
-      { progressLoaded &&
-        <progress
-          value={progressLoaded}
-          max={progressTotal}
-        >
-          {percentage}% uploaded…
-        </progress>
-      }
-      <p>Please be patient while we upload your request.</p>
-    </div>
+    <button disabled>
+      { content }
+    </button>
   );
 }
 

--- a/js/components/upload_progress.jsx
+++ b/js/components/upload_progress.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+function UploadProgress({ progressLoaded, progressTotal }) {
+  const percentage = Math.floor(progressLoaded / progressTotal * 100);
+  return (
+    <div>
+      { progressLoaded &&
+        <progress
+          value={progressLoaded}
+          max={progressTotal}
+        >
+          {percentage}% uploaded…
+        </progress>
+      }
+      <p>Please be patient while we upload your request.</p>
+    </div>
+  );
+}
+
+UploadProgress.propTypes = {
+  progressLoaded: PropTypes.number,
+  progressTotal: PropTypes.number,
+};
+
+UploadProgress.defaultProps = {
+  progressTotal: 0,
+  progressLoaded: 0,
+};
+
+
+export default UploadProgress;

--- a/js/pages/agency_component_request.jsx
+++ b/js/pages/agency_component_request.jsx
@@ -21,12 +21,12 @@ class AgencyComponentRequestPage extends Component {
     const agencyComponentId = props.match.params.agencyComponentId;
     const agencyComponent = agencyComponentStore.getAgencyComponent(agencyComponentId);
     const requestForm = agencyComponentRequestFormStore.getAgencyComponentForm(agencyComponentId);
-    const { formData, isSubmitting, submissionResult } = foiaRequestStore.getState();
+    const { formData, upload, submissionResult } = foiaRequestStore.getState();
 
     return {
       agencyComponent,
       formData,
-      isSubmitting,
+      upload,
       submissionResult,
       requestForm,
     };
@@ -92,7 +92,7 @@ class AgencyComponentRequestPage extends Component {
       mainContent = (
         <FoiaRequestForm
           formData={this.state.formData}
-          isSubmitting={this.state.isSubmitting}
+          upload={this.state.upload}
           onSubmit={onSubmit}
           requestForm={requestForm}
           submissionResult={this.state.submissionResult}

--- a/js/pages/agency_component_request.jsx
+++ b/js/pages/agency_component_request.jsx
@@ -10,6 +10,7 @@ import agencyComponentStore from 'stores/agency_component';
 import agencyComponentRequestFormStore from 'stores/agency_component_request_form';
 import foiaRequestStore from 'stores/foia_request';
 import NotFound from './not_found';
+import { scrollOffset } from '../util/dom';
 
 
 class AgencyComponentRequestPage extends Component {
@@ -76,7 +77,10 @@ class AgencyComponentRequestPage extends Component {
       return <NotFound />;
     }
 
-    function onSubmit() {}
+    const onSubmit = () => {
+      // Scroll to the top of the page.
+      window.scrollTo(0, scrollOffset(this.element));
+    };
 
     let mainContent;
     if (submissionResult && submissionResult.submission_id) {
@@ -104,7 +108,7 @@ class AgencyComponentRequestPage extends Component {
     }
 
     return (
-      <div className="usa-grid-full grid-flex grid-left">
+      <div className="usa-grid-full grid-flex grid-left" ref={(ref) => { this.element = ref; }}>
         {
           agencyComponent && requestForm ?
             <Tabs

--- a/js/stores/foia_request.js
+++ b/js/stores/foia_request.js
@@ -18,7 +18,7 @@ class FoiaRequestStore extends Store {
 
     this.state = {
       formData: new Map(),
-      isSubmitting: false,
+      upload: new Map(),
       submissionResult: new SubmissionResult(),
     };
   }
@@ -40,12 +40,16 @@ class FoiaRequestStore extends Store {
       }
 
       case types.REQUEST_FORM_SUBMIT: {
-        if (this.state.isSubmitting) {
+        if (this.state.upload.get('inProgress')) {
           break;
         }
 
         Object.assign(this.state, {
-          isSubmitting: true,
+          upload: this.state.upload.merge({
+            inProgress: true,
+            progressLoaded: 0,
+            progressTotal: 0,
+          }),
           // Reset the previous submission results
           submission_id: null,
           errorMessage: null,
@@ -55,11 +59,27 @@ class FoiaRequestStore extends Store {
         break;
       }
 
+      case types.REQUEST_FORM_SUBMIT_PROGRESS: {
+        const progress = payload.progress;
+        if (!progress.lengthComputable) {
+          break;
+        }
+
+        Object.assign(this.state, {
+          upload: this.state.upload.merge({
+            progressLoaded: progress.loaded,
+            progressTotal: progress.total,
+          }),
+        });
+        this.__emitChange();
+        break;
+      }
+
       case types.REQUEST_FORM_SUBMIT_COMPLETE: {
         const { submissionResult } = this.state;
         Object.assign(this.state, {
           submissionResult: submissionResult.clear().merge(payload.submissionResult),
-          isSubmitting: false,
+          upload: this.state.upload.clear(),
         });
         this.__emitChange();
         break;

--- a/js/test/components/foia_request_form.test.jsx
+++ b/js/test/components/foia_request_form.test.jsx
@@ -63,9 +63,11 @@ describe('FoiaRequestForm', () => {
       let requestForm;
       let submissionResult;
       let element;
+      let upload;
 
       beforeEach(() => {
         formData = new Map();
+        upload = new Map();
         submissionResult = new SubmissionResult();
         requestForm = simpleSingleSectionRequestForm();
       });
@@ -75,7 +77,7 @@ describe('FoiaRequestForm', () => {
           element = shallow(
             <FoiaRequestForm
               formData={formData}
-              isSubmitting={false}
+              upload={upload}
               requestForm={requestForm}
               submissionResult={submissionResult}
             />,
@@ -92,7 +94,7 @@ describe('FoiaRequestForm', () => {
           element = render(
             <FoiaRequestForm
               formData={formData}
-              isSubmitting={false}
+              upload={upload}
               requestForm={requestForm}
               submissionResult={submissionResult}
             />,
@@ -122,7 +124,7 @@ describe('FoiaRequestForm', () => {
           element = shallow(
             <FoiaRequestForm
               formData={formData}
-              isSubmitting={false}
+              upload={upload}
               onSubmit={onSubmit}
               requestForm={requestForm}
               submissionResult={submissionResult}
@@ -174,7 +176,7 @@ describe('FoiaRequestForm', () => {
           element = render(
             <FoiaRequestForm
               formData={formData}
-              isSubmitting={false}
+              upload={upload}
               requestForm={requestForm}
               submissionResult={submissionResult}
             />,

--- a/js/test/util/attachment.test.js
+++ b/js/test/util/attachment.test.js
@@ -5,40 +5,37 @@ import { dataUrlToAttachment } from '../../util/attachment';
 
 describe('util/attachment', () => {
   describe('dataUrlToAttachment()', () => {
-    it('returns null for empty string', () => {
-      expect(dataUrlToAttachment('')).to.equal(null);
+    it('given empty string, returns an empty array', () => {
+      expect(dataUrlToAttachment('')).to.deep.equal([]);
     });
 
-    it('returns null for null', () => {
-      expect(dataUrlToAttachment(null)).to.equal(null);
+    it('given empty string, returns an empty array', () => {
+      expect(dataUrlToAttachment(null)).to.deep.equal([]);
     });
 
     it('parses urls with no attributes', () => {
-      expect(dataUrlToAttachment('data:text/plain,hello%20world')).to.deep.equal({
+      expect(dataUrlToAttachment('data:text/plain,hello%20world')).to.deep.equal([{
         content_type: 'text/plain',
         filedata: 'hello%20world',
-      });
+      }]);
     });
 
     it('parses attributes', () => {
-      expect(dataUrlToAttachment('data:text/plain;filename=foo.txt;size=233;base64,AAAA')).to.deep.equal({
+      expect(dataUrlToAttachment('data:text/plain;filename=foo.txt;filesize=233;base64,AAAA')).to.deep.equal([{
         filename: 'foo.txt',
-        size: 233,
+        filesize: 233,
         content_type: 'text/plain',
         filedata: 'AAAA',
-      });
+      }]);
     });
 
     it('url decodes filename attribute', () => {
-      expect(dataUrlToAttachment('data:text/plain;filename=foo%20bar.txt;size=233;base64,AAAA')).to.deep.equal({
+      expect(dataUrlToAttachment('data:text/plain;filename=foo%20bar.txt;filesize=233;base64,AAAA')).to.deep.equal([{
         filename: 'foo bar.txt',
-        size: 233,
+        filesize: 233,
         content_type: 'text/plain',
         filedata: 'AAAA',
-      });
+      }]);
     });
-  });
-
-  describe('fileFieldsToAttachment()', () => {
   });
 });

--- a/js/test/util/attachment.test.js
+++ b/js/test/util/attachment.test.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+
+import { dataUrlToAttachment } from '../../util/attachment';
+
+
+describe('util/attachment', () => {
+  describe('dataUrlToAttachment()', () => {
+    it('returns null for empty string', () => {
+      expect(dataUrlToAttachment('')).to.equal(null);
+    });
+
+    it('returns null for null', () => {
+      expect(dataUrlToAttachment(null)).to.equal(null);
+    });
+
+    it('parses urls with no attributes', () => {
+      expect(dataUrlToAttachment('data:text/plain,hello%20world')).to.deep.equal({
+        content_type: 'text/plain',
+        filedata: 'hello%20world',
+      });
+    });
+
+    it('parses attributes', () => {
+      expect(dataUrlToAttachment('data:text/plain;filename=foo.txt;size=233;base64,AAAA')).to.deep.equal({
+        filename: 'foo.txt',
+        size: 233,
+        content_type: 'text/plain',
+        filedata: 'AAAA',
+      });
+    });
+
+    it('url decodes filename attribute', () => {
+      expect(dataUrlToAttachment('data:text/plain;filename=foo%20bar.txt;size=233;base64,AAAA')).to.deep.equal({
+        filename: 'foo bar.txt',
+        size: 233,
+        content_type: 'text/plain',
+        filedata: 'AAAA',
+      });
+    });
+  });
+
+  describe('fileFieldsToAttachment()', () => {
+  });
+});

--- a/js/util/attachment.js
+++ b/js/util/attachment.js
@@ -1,0 +1,35 @@
+/* eslint-disable import/prefer-default-export */
+export function dataUrlToAttachment(dataUrl) {
+  if (!dataUrl || !dataUrl.length) {
+    return null;
+  }
+
+  const [propertiesString, filedata] = dataUrl.split(':', 2)[1].split(',');
+  const properties = propertiesString.split(';');
+  const content_type = properties.shift();
+  return properties.reduce((attachment, property) => {
+    const [key, value] = property.split('=');
+    if (key === 'filename') {
+      attachment[key] = decodeURIComponent(value);
+    }
+
+    if (key === 'filesize') {
+      attachment[key] = parseInt(value, 10);
+    }
+
+    return attachment;
+  }, { content_type, filedata });
+}
+
+// Returns a list of field names that are file fields.
+export function findFileFields(requestForm) {
+  return Object.keys(requestForm.uiSchema)
+    .map((sectionId) => {
+      const uiSchemaSection = requestForm.uiSchema[sectionId];
+
+      // Find file fields in this section
+      return Object.keys(uiSchemaSection)
+        .filter(fieldName => uiSchemaSection[fieldName]['ui:widget'] === 'file');
+    })
+    .reduce((fileFields, sectionFileFields) => fileFields.concat(sectionFileFields), []);
+}

--- a/js/util/attachment.js
+++ b/js/util/attachment.js
@@ -4,6 +4,11 @@ export function dataUrlToAttachment(dataUrl) {
     return [];
   }
 
+  // We augment the data url to include properties we need for the API. It
+  // should look like this:
+  // data:text/plain;filename=foo.txt;filesize=445;base64,AAAAA=
+  // We add these properties. Out of the box, react-jsonschema-form also uses a
+  // data url but they only include a `name` attribute.
   const [propertiesString, filedata] = dataUrl.split(':', 2)[1].split(',');
   const properties = propertiesString.split(';');
   const content_type = properties.shift();

--- a/js/util/attachment.js
+++ b/js/util/attachment.js
@@ -1,13 +1,15 @@
 /* eslint-disable import/prefer-default-export */
 export function dataUrlToAttachment(dataUrl) {
   if (!dataUrl || !dataUrl.length) {
-    return null;
+    return [];
   }
 
   const [propertiesString, filedata] = dataUrl.split(':', 2)[1].split(',');
   const properties = propertiesString.split(';');
   const content_type = properties.shift();
-  return properties.reduce((attachment, property) => {
+
+  // Return an array of a single attachment
+  return [properties.reduce((attachment, property) => {
     const [key, value] = property.split('=');
     if (key === 'filename') {
       attachment[key] = decodeURIComponent(value);
@@ -18,7 +20,7 @@ export function dataUrlToAttachment(dataUrl) {
     }
 
     return attachment;
-  }, { content_type, filedata });
+  }, { content_type, filedata })];
 }
 
 // Returns a list of field names that are file fields.

--- a/js/util/dom.js
+++ b/js/util/dom.js
@@ -1,0 +1,10 @@
+/* eslint-disable import/prefer-default-export */
+/*
+ * DOM utilities
+ */
+
+// Calculates the page offset in order to be used with window.scrollTo and
+// scroll the page to a specific location.
+export function scrollOffset(element) {
+  return element.offsetTop + (element.offsetParent ? scrollOffset(element.offsetParent) : 0);
+}


### PR DESCRIPTION
react-jsonschema-form treats file data as a data url. We need to convert this to an array of objects before sending to the API #272 
- Adds a scroll to top after successful submission #310 
- Stores size and filename in the data url #296 

Todo
- [ ] Update confirmation to render an attachment