### PR TITLE
Add messaging when no form exists for the agency

### DIFF
--- a/js/components/agency_component_preview.jsx
+++ b/js/components/agency_component_preview.jsx
@@ -5,6 +5,7 @@ import AgencyComponentProcessingTime from './agency_component_processing_time';
 import FoiaPersonnel from './foia_personnel';
 import FoiaSubmissionAddress from './foia_submission_address';
 import PrettyUrl from './pretty_url';
+import NonInteroperableInfo from './non_interoperable_info';
 import { AgencyComponent } from '../models';
 
 
@@ -69,12 +70,15 @@ function AgencyComponentPreview({ onAgencySelect, agencyComponent, isCentralized
           <p>To see what’s been made available, you can visit an agency’s
             <a href={agencyComponent.reading_rooms[0].uri}> FOIA reading room</a>.</p>
         }
-        <a
-          className="usa-button usa-button-primary start-request"
-          href={requestUrl}
-        >
-          Start FOIA request
-        </a>
+        { agencyComponent.request_form ?
+          <a
+            className="usa-button usa-button-primary start-request"
+            href={requestUrl}
+          >
+            Start FOIA request
+          </a> :
+          <NonInteroperableInfo agencyComponent={agencyComponent} />
+        }
       </div>
     </div>
   );

--- a/js/components/non_interoperable_info.jsx
+++ b/js/components/non_interoperable_info.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+function NonInteroperableInfo({ agencyComponent }) {
+  const submissionUrl = agencyComponent.submission_web && agencyComponent.submission_web.uri;
+  const submissionInstructions = /^https?:/.test(submissionUrl) ?
+    (
+      <span>
+        You can submit a request to this agency using the information found
+        at the agency’s <a href={submissionUrl}>online submission form</a>.
+      </span>
+    ) : (
+      <span>
+        Use the information to the left in order to submit a FOIA request to this agency.
+      </span>
+    );
+
+  return (
+    <p>
+      Currently, this agency’s FOIA process is not linked to
+      FOIA.gov. {submissionInstructions}
+    </p>
+  );
+}
+
+NonInteroperableInfo.propTypes = {
+  agencyComponent: PropTypes.object.isRequired,
+};
+
+export default NonInteroperableInfo;


### PR DESCRIPTION
Some agencies will not be interoperable with the Portal initially. These
agencies will not have a form populated which allows us to detect this scenario.
In most cases, the agency has an existing online web form, so we link to that
when available.

Implements #235 

Example agency with an online submission form:

![screenshot from 2017-11-06 15-45-16](https://user-images.githubusercontent.com/509703/32469898-abd6fe32-c309-11e7-8f3f-3013d4ed48a3.png)

Example agency with no online submission form:

![screenshot from 2017-11-06 15-45-53](https://user-images.githubusercontent.com/509703/32469915-b7c2c1ea-c309-11e7-9c69-752b8b079f60.png)

