### PR TITLE
Use primary arrow in nav dropdown

### DIFF
--- a/www.foia.gov/_sass/theme/_navbar.scss
+++ b/www.foia.gov/_sass/theme/_navbar.scss
@@ -49,6 +49,7 @@
   }
   button[aria-expanded=true] {
     background-color: $color-white;
+    background-image: url('/assets/img/angle-arrow-down-primary.svg');
     color: $color-primary-darkest;
     &:hover {
       background-color: $color-white;


### PR DESCRIPTION
Avoids using the white arrow indicator on a white background.

Addresses https://github.com/18F/beta.foia.gov/issues/358