### PR TITLE
Make footer work better for responsive layout

### DIFF
--- a/www.foia.gov/_includes/footer.html
+++ b/www.foia.gov/_includes/footer.html
@@ -1,33 +1,31 @@
 <!-- Start Footer -->
 <footer class="usa-footer">
   <div class="usa-grid-full">
-    <div class="usa-width-seven-twelfths">
-      <div class="usa-grid">
-        <div class="usa-width-one-half">
-            <img class="footer-logo" src="{{ site.baseurl }}/img/foia-doj-logo-light.svg" alt="Foia.gov">
-            <h2>FOIA.gov</h2>
-        </div>
-        <div class="usa-width-one-half">
-          <h6>Contact</h6>
-          <ul class="usa-unstyled-list">
-            <li>Office of Information Policy (OIP)</li>
-            <li>U.S. Department of Justice</li>
-            <li>Suite 11050</li>
-            <li>1425 New York Avenue, N.W.</li>
-            <li>Washington, D.C. 20530</li>
-            <li>E-mail: <a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
-          </ul>
-        </div>
+    <div class="usa-grid">
+      <div class="usa-width-one-whole footer-logo">
+	  <img class="footer-logo_img" src="{{ site.baseurl }}/img/foia-doj-logo-light.svg" alt="Foia.gov">
+          <h2>FOIA.gov</h2>
       </div>
     </div>
-    <div class="usa-width-five-twelfths">
-      <div class="usa-grid-full">
-        <ul class="usa-unstyled-list footer-links usa-width-one-half">
+    <div class="usa-grid">
+      <div class="usa-width-one-half">
+        <h6>Contact</h6>
+        <ul class="usa-unstyled-list">
+          <li>Office of Information Policy (OIP)</li>
+          <li>U.S. Department of Justice</li>
+          <li>Suite 11050</li>
+          <li>1425 New York Avenue, N.W.</li>
+          <li>Washington, D.C. 20530</li>
+          <li>E-mail: <a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
+        </ul>
+      </div>
+      <div class="usa-width-one-half footer-links">
+        <ul class="usa-unstyled-list footer-links_list usa-width-one-half">
           <li><a href="{{ site.baseurl }}/sitemap.html">Site map</a></li>
           <li><a href="{{ site.baseurl }}/quality.html">Information quality</a></li>
           <li><a href="{{ site.baseurl }}/developer/">Developer resources</a></li>
         </ul>
-        <ul class="usa-unstyled-list footer-links usa-width-one-half">
+        <ul class="usa-unstyled-list footer-links_list usa-width-one-half">
           <li><a href="https://www.justice.gov/accessibility/accessibility-information">Accessibility</a></li>
           <li><a href="https://www.justice.gov/doj/privacy-policy">Privacy policy</a></li>
           <li><a href="https://www.justice.gov/legalpolicies">Policies &amp; disclaimers</a></li>

--- a/www.foia.gov/_sass/_base.scss
+++ b/www.foia.gov/_sass/_base.scss
@@ -3,4 +3,5 @@
 
 @import 'base/print';
 @import 'base/typography';
+@import 'base/utilities';
 @import 'base/z-index';

--- a/www.foia.gov/_sass/base/_utilities.scss
+++ b/www.foia.gov/_sass/base/_utilities.scss
@@ -1,0 +1,5 @@
+.clearfix::after {
+    clear: both;
+    content: '';
+    display: table;
+}

--- a/www.foia.gov/_sass/modules/_site_footer.scss
+++ b/www.foia.gov/_sass/modules/_site_footer.scss
@@ -5,6 +5,10 @@
   font-size: $small-font-size;
   border-top: 3px solid $color-white;
   .footer-logo {
+    @extend .clearfix;
+    margin-bottom: $space-2x;
+  }
+  .footer-logo_img {
     max-width: 8rem;
     display: inline-block;
     float: left;
@@ -33,6 +37,10 @@
     }
   }
   .footer-links {
+    margin-top: $space-2x;
+  }
+
+  .footer-links_list {
     padding-right: 4px;
     a {
       letter-spacing: 0.065rem;

--- a/www.foia.gov/_sass/modules/_site_header.scss
+++ b/www.foia.gov/_sass/modules/_site_header.scss
@@ -1,3 +1,9 @@
+.usa-banner-button {
+  @media screen and (max-width: $small-screen) {
+    display: none;
+  }
+}
+
 .doj-banner {
   background-color: $color-black;
   img {


### PR DESCRIPTION
This is not ideal, but the footer content is just a bit big for our 5/7-6/6 grid
layout. This pulls the logo out so there is more space for the content as the
columns shrink.

Fixes the footer's gutter on mobile.