### PR TITLE
Revert "Add conditional to handle case where there is no agency"

### DIFF
--- a/js/stores/agency_component.js
+++ b/js/stores/agency_component.js
@@ -45,19 +45,17 @@ class AgencyComponentStore extends Store {
           receivedAgencyComponents
             .map(agencyComponent => agencyComponent.agency)
             .forEach((agency) => {
-              if (agency) {
-                mutableAgencies.update(
-                  agency.id,
-                  new Agency(), // not set value
-                  (existingAgency) => {
-                    const { component_count } = existingAgency;
-                    return existingAgency.merge(
-                      new Agency(agency),
-                      { component_count: component_count + 1 },
-                    );
-                  },
-                );
-              }
+              mutableAgencies.update(
+                agency.id,
+                new Agency(), // not set value
+                (existingAgency) => {
+                  const { component_count } = existingAgency;
+                  return existingAgency.merge(
+                    new Agency(agency),
+                    { component_count: component_count + 1 },
+                  );
+                },
+              );
             });
         });
 


### PR DESCRIPTION
Reverts usdoj/foia.gov#494. This fix only kicked the can down the road, where it eventually failed in agency_component_finder.jsx line 36.