### PR TITLE
Indicate agency finder is loading

### DIFF
--- a/js/components/agency_component_finder.jsx
+++ b/js/components/agency_component_finder.jsx
@@ -134,6 +134,7 @@ class AgencyComponentFinder extends Component {
   }
 
   render() {
+    const loading = !this.props.agencyFinderDataComplete;
     const onSubmit = (e) => {
       e.preventDefault();
       this.bloodhound.search(this.typeahead.typeahead('val'), (suggestions) => {
@@ -146,6 +147,13 @@ class AgencyComponentFinder extends Component {
       });
     };
 
+    const buttonClasses = ['usa-button', 'usa-sr-hidden'];
+    if (loading) {
+      buttonClasses.push('usa-button-disabled');
+    } else {
+      buttonClasses.push('usa-button-primary');
+    }
+
     return (
       <form className="usa-search usa-search-big" onSubmit={onSubmit}>
         <div role="search">
@@ -157,8 +165,14 @@ class AgencyComponentFinder extends Component {
             placeholder="Type agency name"
             ref={(input) => { this.typeaheadInput = input; }}
           />
-          <button className="usa-button usa-button-primary usa-sr-hidden" type="submit">
-            <span className="usa-search-submit-text">Search</span>
+          <button
+            className={buttonClasses.join(' ')}
+            disabled={loading}
+            type="submit"
+          >
+            <span className="usa-search-submit-text">
+              { loading ? 'Loading…' : 'Search' }
+            </span>
           </button>
         </div>
       </form>

--- a/js/components/agency_component_finder.jsx
+++ b/js/components/agency_component_finder.jsx
@@ -134,6 +134,7 @@ class AgencyComponentFinder extends Component {
   }
 
   render() {
+    const { agencyFinderDataProgress } = this.props;
     const loading = !this.props.agencyFinderDataComplete;
     const onSubmit = (e) => {
       e.preventDefault();
@@ -171,7 +172,7 @@ class AgencyComponentFinder extends Component {
             type="submit"
           >
             <span className="usa-search-submit-text">
-              { loading ? 'Loading…' : 'Search' }
+              { loading ? `Loading… ${agencyFinderDataProgress}%` : 'Search' }
             </span>
           </button>
         </div>
@@ -187,11 +188,13 @@ AgencyComponentFinder.propTypes = {
   /* eslint-enable react/no-unused-prop-types */
   onAgencyChange: PropTypes.func.isRequired,
   agencyFinderDataComplete: PropTypes.bool.isRequired,
+  agencyFinderDataProgress: PropTypes.number,
 };
 
 AgencyComponentFinder.defaultProps = {
   agencies: new Map(),
   agencyComponents: new List(),
+  agencyFinderDataProgress: 0,
 };
 
 export default AgencyComponentFinder;

--- a/js/components/landing.jsx
+++ b/js/components/landing.jsx
@@ -79,7 +79,13 @@ class LandingComponent extends Component {
       this.setStateForAgency(agency, agencyComponentsForAgency);
     };
 
-    const { agencies, agencyComponents, agencyFinderDataComplete } = this.props;
+    const {
+      agencies,
+      agencyComponents,
+      agencyFinderDataComplete,
+      agencyFinderDataProgress,
+    } = this.props;
+
     return (
       <div className="usa-grid">
         <h2 className="agency-component-search_hed">
@@ -90,6 +96,7 @@ class LandingComponent extends Component {
             agencies={agencies}
             agencyComponents={agencyComponents}
             agencyFinderDataComplete={agencyFinderDataComplete}
+            agencyFinderDataProgress={agencyFinderDataProgress}
             onAgencyChange={agencyChange}
           />
         </div>
@@ -128,6 +135,12 @@ LandingComponent.propTypes = {
   agencies: PropTypes.object.isRequired,
   agencyComponents: PropTypes.object.isRequired,
   agencyFinderDataComplete: PropTypes.bool.isRequired,
+  agencyFinderDataProgress: PropTypes.number,
 };
+
+LandingComponent.defaultProps = {
+  agencyFinderDataProgress: 0,
+};
+
 
 export default LandingComponent;

--- a/js/pages/landing.jsx
+++ b/js/pages/landing.jsx
@@ -16,12 +16,14 @@ class LandingPage extends Component {
       agencies,
       agencyComponents,
       agencyFinderDataComplete,
+      agencyFinderDataProgress,
     } = agencyComponentStore.getState();
 
     return {
       agencies,
       agencyComponents,
       agencyFinderDataComplete,
+      agencyFinderDataProgress,
     };
   }
 
@@ -37,12 +39,19 @@ class LandingPage extends Component {
 
 
   render() {
-    const { agencies, agencyComponents, agencyFinderDataComplete } = this.state;
+    const {
+      agencies,
+      agencyComponents,
+      agencyFinderDataComplete,
+      agencyFinderDataProgress,
+    } = this.state;
+
     return (
       <LandingComponent
         agencies={agencies}
         agencyComponents={agencyComponents}
         agencyFinderDataComplete={agencyFinderDataComplete}
+        agencyFinderDataProgress={agencyFinderDataProgress}
       />
     );
   }


### PR DESCRIPTION
Helps signal to user that the finder isn't ready for interaction until the data
is fully loaded. Usually this is within a few seconds so a user could easily
start interacting with the finder before it is loaded and end up confused.