### PR TITLE
Added header information for POST in API developer docs

### DIFF
--- a/www.foia.gov/developer/index.md
+++ b/www.foia.gov/developer/index.md
@@ -110,7 +110,7 @@ $ curl -H 'X-API-Key: <your-api-key>' https://api.foia.gov/api/agency_components
 Submit a request to the Office of Information Policy.
 
 ```
-curl -v -H 'X-Api-Key: <your-api-key>' https://api.foia.gov/api/webform/submit?_format=json --data-binary @- <<EOF
+curl -v -H 'X-Api-Key: <your-api-key>' -H 'Content-Type: application/json' https://api.foia.gov/api/webform/submit?_format=json --data-binary @- <<EOF
 {
     "id": "test_form",
     "email": "george@example.com",


### PR DESCRIPTION
Because the payload is a JSON file, you need to pass a request header that indicates that the payload is an `application/json` Content-Type.

I tested this on a FOIA request and it worked.