### PR TITLE
Allow using APP_ENV values with `make serve`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ clean:
 
 serve.dev:
 	-pkill -9 -f "node js/dev-server.js"
-	APP_ENV=development node js/dev-server.js
+	node js/dev-server.js
 
 serve:
 	npx npm-run-all --parallel serve:watch serve:dev

--- a/js/dev-server.js
+++ b/js/dev-server.js
@@ -8,7 +8,7 @@ const port = process.env.PORT || '4000';
 
 // Serve static files from the Jekyll build
 const static_path = path.resolve(path.join(__dirname), '..', '_site');
-
+const assets_path = path.resolve(path.join(__dirname), '..', 'www.foia.gov', 'assets');
 
 /**
  * Event listener for HTTP server "error" event.
@@ -54,6 +54,7 @@ const app = express();
 
 app.set('port', port);
 
+app.use('/assets', express.static(assets_path));
 app.use(express.static(static_path));
 
 // Serve the request single-page app from all endpoints.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "webpack",
     "lint": "eslint --ext jsx,js js/",
     "test": "mochapack --webpack-config webpack.config.test.js js/**.test.js*",
-    "serve:watch": "APP_ENV=development webpack --watch --progress --config webpack.config.dev.js",
+    "serve:watch": "webpack --watch --progress --config webpack.config.dev.js",
     "serve:dev": "APP_ENV=development make serve.dev"
   },
   "repository": {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -4,11 +4,11 @@ const webpack = require('webpack');
 const exec = require('child_process').exec;
 const WebpackWatchPlugin = require('webpack-watch-files-plugin').default;
 
-const env = 'development';
+const env = process.env.APP_ENV || 'development';
 assert(['local', 'cloud-gov', 'development', 'staging', 'uat', 'production', 'ddev'].includes(env), `${env} is not an acceptable environment.`);
 
 module.exports = {
-  mode: env,
+  mode: 'development',
   devtool: 'eval-source-map',
   watchOptions: {
     ignored: /node_modules/,


### PR DESCRIPTION
This allows the dev webpack config to use a specified APP_ENV value during `make serve` and fixes the dev server to serve assets from the `www.foia.gov/assets` directory.