### PR TITLE
Zero-pad day of month in getCurrentDate

### DIFF
--- a/js/test/util/current_date.test.js
+++ b/js/test/util/current_date.test.js
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import currentDate from '../../util/current_date';
+
+describe('current_date', () => {
+  const { getCurrentDate } = currentDate;
+
+  let clock;
+
+  afterEach(() => {
+    if (clock) {
+      clock.restore();
+      clock = null;
+    }
+  });
+
+  it('zero-pads a single-digit day of month', () => {
+    // June 7, 2026
+    clock = sinon.useFakeTimers(new Date(2026, 5, 7).getTime());
+    expect(getCurrentDate('-')).to.equal('2026-06-07');
+  });
+
+  it('zero-pads single-digit month and day together', () => {
+    // January 5, 2026
+    clock = sinon.useFakeTimers(new Date(2026, 0, 5).getTime());
+    expect(getCurrentDate('-')).to.equal('2026-01-05');
+  });
+
+  it('leaves a two-digit day unchanged', () => {
+    // June 15, 2026
+    clock = sinon.useFakeTimers(new Date(2026, 5, 15).getTime());
+    expect(getCurrentDate('-')).to.equal('2026-06-15');
+  });
+});

--- a/js/util/current_date.js
+++ b/js/util/current_date.js
@@ -4,7 +4,7 @@ function getCurrentDate(separator = '') {
   const month = newDate.getMonth() + 1;
   const year = newDate.getFullYear();
 
-  return `${year}${separator}${month < 10 ? `0${month}` : `${month}`}${separator}${date}`;
+  return `${year}${separator}${month < 10 ? `0${month}` : `${month}`}${separator}${date < 10 ? `0${date}` : `${date}`}`;
 }
 
 export default {


### PR DESCRIPTION
getCurrentDate zero-pads the month but not the day, so on the 1st through 9th of a month it returns dates like 2026-06-7 instead of 2026-06-07. That breaks the YYYY-MM-DD format the month padding is clearly aiming for.

Where it bites is the agency-finder date filter: getCurrentDate('-') is passed as the rep_start filter value in js/actions/report.js and js/actions/quarterly_report.js, so for the first nine days of each month the rep_start <= <date> filter gets a non-zero-padded day.

The fix applies the same single-digit guard to the day that already exists for the month. I also added a small unit test (with sinon fake timers) covering a single-digit day, a single-digit month and day together, and a two-digit day control.

One note: the repo's npm test glob (js/**.test.js*) doesn't match anything under js/test/, so I ran the new test by explicit path with mochapack. Happy to adjust if you'd like it wired into the suite differently. Thanks for taking a look.
